### PR TITLE
Added blurAmount to defaultProps

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ const Menu = React.createClass({
   - `xlight` - extra light blur type
   - `light` - light blur type
   - `dark` - dark blur type
-- `blurAmount` (Number) - blur amount effect
+- `blurAmount` (Default: 10, Number) - blur amount effect
   - `0-100` - Adjusts blur intensity
 
 *Note: `blurAmount` does not refresh with Hot Reloading. You must a refresh the app to view the results of the changes*

--- a/src/BlurView.ios.js
+++ b/src/BlurView.ios.js
@@ -17,7 +17,11 @@ class BlurView extends Component {
 
 BlurView.propTypes = {
   blurType: PropTypes.string,
-  blurAmount: PropTypes.number,
+  blurAmount: PropTypes.number.isRequired,
+};
+
+BlurView.defaultProps = {
+  blurAmount: 10,
 };
 
 const NativeBlurView = requireNativeComponent('BlurView', BlurView);


### PR DESCRIPTION
Since last update, we can now adjust the blur amount: https://github.com/react-native-community/react-native-blur/pull/102

The issue is that the app will crash in a production environment if no `blurAmount` is provided to `blurView` on iOS. See https://github.com/react-native-community/react-native-blur/issues/103

So I provided a default value of 10 for this prop. Let me know if you want to change it.

