### PR TITLE
Fix incorrectly assigning an NSNumber to blurEffect which resulted in a crash on -layoutSubviews

### DIFF
--- a/ios/BlurView.m
+++ b/ios/BlurView.m
@@ -27,7 +27,7 @@
 
 - (void)setBlurAmount:(NSNumber *)blurAmount
 {
-    blurEffect = [BlurAmount updateBlurAmount:blurAmount];
+    [BlurAmount updateBlurAmount:blurAmount];
 }
 
 


### PR DESCRIPTION
`-[BlurAmount updateBlurAmount:]` returns its argument (an NSNumber) as the result. Assigning that to `blurEffect` causes a crash in `-[BlurView layoutSubviews]` when the value is used. This change prevents that crash from happening.