### PR TITLE
Moved creation of _visualEffectView out of layoutSubviews

### DIFF
--- a/ios/BlurView.m
+++ b/ios/BlurView.m
@@ -4,7 +4,7 @@
 
 @implementation BlurView {
   UIVisualEffectView *_visualEffectView;
-  BlurView *blurEffect;
+  UIBlurEffect * blurEffect;
 }
 
 - (void)setBlurType:(NSString *)blurType
@@ -22,21 +22,18 @@
   } else {
     blurEffect = [BlurAmount effectWithStyle:UIBlurEffectStyleDark];
   }
-
+    
+    dispatch_async(dispatch_get_main_queue(), ^{
+        _visualEffectView = [[UIVisualEffectView alloc] initWithEffect:blurEffect];
+        _visualEffectView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+        _visualEffectView.frame = self.bounds;
+        [self insertSubview:_visualEffectView atIndex:0];
+    });
 }
 
 - (void)setBlurAmount:(NSNumber *)blurAmount
 {
     [BlurAmount updateBlurAmount:blurAmount];
-}
-
-
-- (void)layoutSubviews
-{
-  [super layoutSubviews];
-  _visualEffectView = [[UIVisualEffectView alloc] initWithEffect:blurEffect];
-  _visualEffectView.frame = self.bounds;
-  [self insertSubview:_visualEffectView atIndex:0];
 }
 
 @end


### PR DESCRIPTION
I discovered a problem when rotating my app. It looked like it was creating a new blur effect and placing it on top of the last one. It's also expensive to create a new UIVisualEffectView on each sublayout, which can happen during animations.

To fix this, I've moved the creation of the UIVisualEffectView up where the blur effect is created.  I also set the auto resizing mask, so the bounds doesn't need to be explicitly updated.