### PR TITLE
Fix duplicate symbols error in xcode

### DIFF
--- a/ios/BlurAmount.h
+++ b/ios/BlurAmount.h
@@ -1,0 +1,7 @@
+#import <UIKit/UIKit.h>
+
+@interface BlurAmount : UIBlurEffect
++ (id)updateBlurAmount:(NSNumber*)blurAmount;
+
+@property (nonatomic, copy) NSNumber *blurAmount;
+@end

--- a/ios/BlurAmount.m
+++ b/ios/BlurAmount.m
@@ -1,13 +1,10 @@
-#import <UIKit/UIKit.h>
+#import "BlurAmount.h"
 #import <objc/runtime.h>
 
 @interface UIBlurEffect (Protected)
 @property (nonatomic, readonly) id effectSettings;
 @end
 
-@interface BlurAmount : UIBlurEffect
-@property (nonatomic, copy) NSNumber *blurAmount;
-@end
 
 @implementation BlurAmount
 

--- a/ios/BlurView.m
+++ b/ios/BlurView.m
@@ -1,5 +1,5 @@
 #import "BlurView.h"
-#import "BlurAmount.m"
+#import "BlurAmount.h"
 
 
 @implementation BlurView {
@@ -12,7 +12,7 @@
   if (_visualEffectView) {
     [_visualEffectView removeFromSuperview];
   }
-  
+
   self.clipsToBounds = true;
   if ([blurType isEqual: @"xlight"]) {
     blurEffect = [BlurAmount effectWithStyle:UIBlurEffectStyleExtraLight];


### PR DESCRIPTION
Hi. After upgrading to 1.1 our build is broken, Xcode build command fails with `duplicate symbols` errors.
<img width="757" alt="1" src="https://cloud.githubusercontent.com/assets/3778452/21388173/2b5ced4e-c78c-11e6-9c7e-1ed5fda201f3.png">

 I searched in stackOverflow for such issues and seems, that it happens because of importing `.m` file from BlurView.m, there are [recommendations](http://stackoverflow.com/a/22877819) to import `.h` files instead. So, in this pr I splitted interface and implementation of BlurAmount and replace `"BlurAmount.m"` with `"BlurAmount.h"`
 in import. These changes won't anyhow affect users.