### PR TITLE
Pass native props to native component

### DIFF
--- a/src/BlurView.android.js
+++ b/src/BlurView.android.js
@@ -2,6 +2,10 @@ import React, { Component, PropTypes } from 'react';
 import { View, requireNativeComponent } from 'react-native';
 
 class BlurView extends Component {
+  setNativeProps(nativeProps) {
+    this._nativeComponent(setNativeProps);
+  }
+
   render() {
     return (
       <NativeBlurView
@@ -10,6 +14,7 @@ class BlurView extends Component {
           backgroundColor: 'transparent',
         }, this.props.style
         ]}
+        ref={(c) => this._nativeComponent = c}
       />
     );
   }

--- a/src/BlurView.ios.js
+++ b/src/BlurView.ios.js
@@ -2,6 +2,10 @@ import React, { Component, PropTypes } from 'react';
 import { requireNativeComponent } from 'react-native';
 
 class BlurView extends Component {
+  setNativeProps(nativeProps) {
+    this._nativeComponent(setNativeProps);
+  }
+
   render() {
     return (
       <NativeBlurView
@@ -10,6 +14,7 @@ class BlurView extends Component {
           backgroundColor: 'transparent',
         }, this.props.style
         ]}
+        ref={(c) => this._nativeComponent = c}
       />
     );
   }

--- a/src/VibrancyView.ios.js
+++ b/src/VibrancyView.ios.js
@@ -2,6 +2,10 @@ import React, { Component, PropTypes } from 'react';
 import { requireNativeComponent } from 'react-native';
 
 class VibrancyView extends Component {
+  setNativeProps(nativeProps) {
+    this._nativeComponent(setNativeProps);
+  }
+
   render() {
     return (
       <NativeVibrancyView
@@ -10,6 +14,7 @@ class VibrancyView extends Component {
           backgroundColor: 'transparent',
         }, this.props.style
         ]}
+        ref={(c) => this._nativeComponent = c}
       />
     );
   }


### PR DESCRIPTION
Currently, components do not pass native props to native component, so we can't directly render them into `TouchableHighlight` without wrapper. Could we add native props passing to the components? 