### PR TITLE
Fixed Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,16 @@ Check the [roadmap here](https://github.com/Kureev/react-native-blur/issues/1)
 3. (Android only) Add the following to your `android/app/build.gradle`
 
 `android/build.gradle`
-  ```
+```
+  buildscript {
+    dependencies {
+        // Update "Android Plugin for Gradle" version
+        classpath 'com.android.tools.build:gradle:2.2.3'
+    }
+  }
+
+  // ...
+
   allprojects {
     repositories {
         maven { url 'https://github.com/500px/500px-android-blur/raw/master/releases/' }
@@ -41,6 +50,21 @@ Check the [roadmap here](https://github.com/Kureev/react-native-blur/issues/1)
 dependencies {
     compile 'com.fivehundredpx:blurringview:1.0.0'
 }
+
+
+android {
+    defaultConfig {
+        // Add these to the existing config
+        renderscriptTargetApi 23
+        renderscriptSupportModeEnabled true
+    }
+}
+```
+
+`android/gradle/wrapper/gradle-wrapper.properties`
+```
+// Update Gradle version
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
 ```
 
 4. Inside your code include JS part by adding

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,6 +34,6 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.19.+'
+    compile 'com.facebook.react:react-native:0.41.+'
     compile 'com.fivehundredpx:blurringview:1.0.0'
 }

--- a/android/src/main/java/com/cmcewen/blurview/BlurViewManager.java
+++ b/android/src/main/java/com/cmcewen/blurview/BlurViewManager.java
@@ -1,5 +1,6 @@
 package com.cmcewen.blurview;
 
+import android.app.Activity;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -14,6 +15,8 @@ public class BlurViewManager extends SimpleViewManager<BlurringView> {
     public static final int defaultRadius = 10;
     public static final int defaultSampling = 10;
 
+    private static Activity currentActivity;
+
     @Override
     public String getName() {
         return REACT_CLASS;
@@ -21,6 +24,8 @@ public class BlurViewManager extends SimpleViewManager<BlurringView> {
 
     @Override
     public BlurringView createViewInstance(ThemedReactContext context) {
+        currentActivity = context.getCurrentActivity();
+
         BlurringView blurringView = new BlurringView(context);
         blurringView.setBlurRadius(defaultRadius);
         blurringView.setDownsampleFactor(defaultSampling);
@@ -44,12 +49,11 @@ public class BlurViewManager extends SimpleViewManager<BlurringView> {
 
     @ReactProp(name = "viewRef")
     public void setViewRef(BlurringView view, int viewRef) {
-        ViewGroup viewGroup = (ViewGroup) view.getRootView().findViewById(viewRef);
-        if (viewGroup != null) {
-            View v = viewGroup.getChildAt(0);
-            view.setBlurredView(v);
+        View blurredView = currentActivity.findViewById(viewRef);
+
+        if (blurredView != null) {
+            view.setBlurredView(blurredView);
             view.invalidate();
         }
     }
 }
-


### PR DESCRIPTION
Fixed the blur on Android. There was a problem with `view.getRootView()`, where it was just returning the same BlurringView instance. So I save the context in `createViewInstance`, and use that to find the referenced view.