### PR TITLE
More clear installation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Check the [roadmap here](https://github.com/Kureev/react-native-blur/issues/1)
 
   allprojects {
     repositories {
+        // Add the following in a new line, underneath "maven { url '$rootDir/../node_modules/react-native/android' }"
         maven { url 'https://github.com/500px/500px-android-blur/raw/master/releases/' }
     }
 }


### PR DESCRIPTION
I was doing the following mistake, when installing this on Android: 

```
maven { 
url '$rootDir/../node_modules/react-native/android' 
url 'https://github.com/500px/500px-android-blur/raw/master/releases/' 
}
```

Instead of doing the proper way, which is:
```
maven { url '$rootDir/../node_modules/react-native/android' }
maven { url 'https://github.com/500px/500px-android-blur/raw/master/releases/' }
```

After this, I noticed that everything was working. 
I hope this helps other people, who are new to Android development.
