### PR TITLE
Fix BlurView blurAmount not work And Crash on iOS8

### DIFF
--- a/ios/BlurAmount.h
+++ b/ios/BlurAmount.h
@@ -1,9 +1,9 @@
 #import <UIKit/UIKit.h>
 
-@interface BlurAmount : UIBlurEffect
+@interface UIBlurEffect (RNBlur)
 
 @property (nonatomic, copy) NSNumber *blurAmount;
 
-+ (id)updateBlurAmount:(NSNumber*)blurAmount;
+- (id)updateBlurAmount:(NSNumber*)blurAmount;
 
 @end

--- a/ios/BlurAmount.m
+++ b/ios/BlurAmount.m
@@ -1,54 +1,52 @@
 #import "BlurAmount.h"
 #import <objc/runtime.h>
 
-@interface UIBlurEffect (Protected)
+@implementation UIBlurEffect (RNBlur)
 
-@property (nonatomic, readonly) id effectSettings;
-@property (nonatomic, copy, class) NSNumber *localBlurAmount;
+NSNumber *localBlurAmount;
 
-@end
-
-
-@implementation BlurAmount
-
-static NSNumber *_localBlurAmount = nil;
-
-+ (instancetype)effectWithStyle:(UIBlurEffectStyle)style
-{
-    id result = [super effectWithStyle:style];
-    object_setClass(result, self);
-
-    return result;
++ (id)invokeOriginalMethod:(id)target selector:(SEL)selector {
+    // Get the class method list
+    uint count;
+    Method *list = class_copyMethodList([target class], &count);
+    
+    // Find and call original method .
+    for ( int i = count - 1 ; i >= 0; i--) {
+        Method method = list[i];
+        SEL name = method_getName(method);
+        IMP imp = method_getImplementation(method);
+        if (name == selector) {
+            return ((id (*)(id, SEL))imp)(target, name);
+            break;
+        }
+    }
+    free(list);
+    return nil;
 }
 
 - (id)effectSettings
 {
-    id settings = [super effectSettings];
-    [settings setValue:BlurAmount.localBlurAmount forKey:@"blurRadius"];
+    id settings = [UIBlurEffect invokeOriginalMethod:self selector:@selector(effectSettings)];
+    if (settings) {
+        [settings setValue:localBlurAmount ? localBlurAmount: [NSNumber numberWithInteger:4]  forKey:@"blurRadius"];
+    }
     return settings;
 }
 
-- (id)copyWithZone:(NSZone*)zone
+- (id)updateBlurAmount:(NSNumber*)blurAmount
 {
-    id result = [super copyWithZone:zone];
-    object_setClass(result, [self class]);
-    return result;
-}
-
-+ (void)setLocalBlurAmount:(NSNumber *)localBlurAmount {
-    if (localBlurAmount != _localBlurAmount) {
-        _localBlurAmount = localBlurAmount;
-    }
-}
-
-+ (NSNumber *)localBlurAmount {
-    return _localBlurAmount;
-}
-
-+ (id)updateBlurAmount:(NSNumber*)blurAmount
-{
-    self.localBlurAmount = blurAmount;
+    localBlurAmount = blurAmount;
     return blurAmount;
+}
+
+- (void)setBlurAmount:(NSNumber*)blurAmount
+{
+    [self updateBlurAmount:blurAmount];
+}
+
+- (NSNumber *)blurAmount
+{
+    return localBlurAmount;
 }
 
 @end

--- a/ios/BlurView.m
+++ b/ios/BlurView.m
@@ -37,12 +37,13 @@
     } else {
         self.blurEffect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleDark];
     }
-    self.visualEffectView.effect = self.blurEffect;
-}
-
-- (void)setBlurAmount:(NSNumber *)blurAmount
-{
-    [BlurAmount updateBlurAmount:blurAmount];
+    self.blurEffect.blurAmount = self.blurAmount;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self.visualEffectView = [[UIVisualEffectView alloc] initWithEffect:self.blurEffect];
+        self.visualEffectView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+        self.visualEffectView.frame = self.bounds;
+        [self bringSubviewToFront:self.visualEffectView];
+    });
 }
 
 @end


### PR DESCRIPTION
1. We found v2.0.0 crashed on iOS8, because [super  effectWithStyle:] called in BlurAmount cause ARC destruct fail. So I use category instead of subclass. 
This is the stack: [image of stack](https://github.com/haywoodfu/Notes/blob/master/Images/stacktrace-20170413.png)
2. self.visualEffectView.effect = self.blurEffect would't trigger [UIBlurEffect effectSettings], the blurAmount did't work. So I still use  self.visualEffectView = [[UIVisualEffectView alloc] initWithEffect:self.blurEffect]; just like v2.0.0