### PR TITLE
Fixed react-native dependency to work with any version from the parent project

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,6 +34,6 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.43.+'
+    compile 'com.facebook.react:react-native:[0.32,)'
     compile 'com.fivehundredpx:blurringview:1.0.0'
 }


### PR DESCRIPTION
This fixes a dependency problem that I introduced on Android. (Errors like [this](https://github.com/react-native-community/react-native-blur/issues/169#issuecomment-294140365) and [this](https://github.com/elanic-tech/react-native-apps-flyer/issues/10).)

Basically, the `build.gradle` file is configured to pull in the `react-native` dependency from the parent project's `node_modules`.

The only thing we really need for Android is [this commit](https://github.com/facebook/react-native/commit/96e41218ed7d33567fb88cc047386f5f8ba48ea6), which adds `getCurrentActivity` to `ThemedReactContext`. That change was released in RN `v0.32.0`. 

So I finally figured out the weird [version-matcher syntax](http://ant.apache.org/ivy/history/2.1.0/settings/version-matchers.html), and I'm setting the minimum React Native version to `0.32`.
