### PR TITLE
Made a few changes to .eslintrc, just to make it a bit more comfortable

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -50,7 +50,7 @@
 /**
  * Possible errors
  */
-    "comma-dangle": [2, "always"],    // http://eslint.org/docs/rules/comma-dangle
+    "comma-dangle": [2, "always-multiline"], // http://eslint.org/docs/rules/comma-dangle
     "no-cond-assign": [2, "always"],  // http://eslint.org/docs/rules/no-cond-assign
     "no-console": 0,                 // http://eslint.org/docs/rules/no-console
     "no-debugger": 1,                // http://eslint.org/docs/rules/no-debugger
@@ -82,11 +82,11 @@
     "dot-notation": [2, {            // http://eslint.org/docs/rules/dot-notation
       "allowKeywords": true
     }],
-    "eqeqeq": 2,                     // http://eslint.org/docs/rules/eqeqeq
+    "eqeqeq": ["error", "smart"],    // http://eslint.org/docs/rules/eqeqeq
     "guard-for-in": 2,               // http://eslint.org/docs/rules/guard-for-in
     "no-caller": 2,                  // http://eslint.org/docs/rules/no-caller
     "no-else-return": 2,             // http://eslint.org/docs/rules/no-else-return
-    "no-eq-null": 2,                 // http://eslint.org/docs/rules/no-eq-null
+    "no-eq-null": 0,                 // http://eslint.org/docs/rules/no-eq-null
     "no-eval": 2,                    // http://eslint.org/docs/rules/no-eval
     "no-extend-native": 2,           // http://eslint.org/docs/rules/no-extend-native
     "no-extra-bind": 2,              // http://eslint.org/docs/rules/no-extra-bind


### PR DESCRIPTION
The `eqeqeq` and `no-eq-null` rules are so you can do `!= null`, to check for null and undefined. `comma-dangle` is so you don't have to add a trailing comma unless there's a newline.