### PR TITLE
Added a postinstall script for the basic example, to fix some packaging issues

### DIFF
--- a/examples/Basic/package.json
+++ b/examples/Basic/package.json
@@ -4,7 +4,8 @@
 	"private": true,
 	"scripts": {
 		"start": "node node_modules/react-native/local-cli/cli.js start",
-		"test": "jest"
+		"test": "jest",
+		"postinstall": "rm -rf node_modules/react-native-blur/.git node_modules/react-native-blur/examples/"
 	},
 	"dependencies": {
 		"react": "16.0.0-alpha.6",

--- a/examples/Basic/yarn.lock
+++ b/examples/Basic/yarn.lock
@@ -2920,11 +2920,11 @@ react-devtools-core@^2.0.8:
     ws "^2.0.3"
 
 "react-native-blur@file:../../":
-  version "2.0.0"
+  version "3.0.0-alpha"
 
-react-native-segmented-android@^1.0.4:
+react-native-segmented-android@sooth-sayer/react-native-segmented-android:
   version "1.0.4"
-  resolved "https://registry.yarnpkg.com/react-native-segmented-android/-/react-native-segmented-android-1.0.4.tgz#223424ab2b6b31acdd90be1ff3d49953a0df2c1d"
+  resolved "https://codeload.github.com/sooth-sayer/react-native-segmented-android/tar.gz/e674a9c0d06f40eec03cc94db106726e2916d671"
 
 react-native@0.43.3:
   version "0.43.3"


### PR DESCRIPTION
I was just doing this manually, to fix packaging issues like the following:

```
This warning is caused by a @providesModule declaration with the same name across two different files.
jest-haste-map: @providesModule naming collision:
  Duplicate module name: Animated
  Paths: /Users/ndbroadbent/code/react-native-blur/examples/Basic/node_modules/react-native-blur/examples/Basic/node_modules/react-native/Libraries/Animated/src/Animated.js collides with /Users/ndbroadbent/code/react-native-blur/examples/Basic/node_modules/react-native/Libraries/Animated/src/Animated.js
```

The `.git` folder needs to be removed from the clone in `node_modules`, to remove this error from `npm`:

```
npm ERR! git /Users/ndbroadbent/code/react-native-blur/examples/Basic/node_modules/react-native-blur: Appears to be a git repo or submodule.
npm ERR! git     /Users/ndbroadbent/code/react-native-blur/examples/Basic/node_modules/react-native-blur
npm ERR! git Refusing to remove it. Update manually,
npm ERR! git or move it out of the way first.
```

(Although that doesn't happen with yarn.)

Then I realized I could automate it with a post-install script. The commit also contains an updated yarn.lock.