### PR TITLE
[tvOS] Add new blur types and setNativeProps

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ android {
   - `xlight` - extra light blur type
   - `light` - light blur type
   - `dark` - dark blur type
+  - `extraDark` - extra dark blur type (tvOS only)
+  - `regular` - regular blur type (tvOS only)
+  - `prominent` - prominent blur type (tvOS only)
 - `blurAmount` (Default: 10, Number)
   - `0-100` - Adjusts blur intensity
 

--- a/ios/BlurView.m
+++ b/ios/BlurView.m
@@ -53,6 +53,13 @@
   if ([self.blurType isEqual: @"xlight"]) return UIBlurEffectStyleExtraLight;
   if ([self.blurType isEqual: @"light"]) return UIBlurEffectStyleLight;
   if ([self.blurType isEqual: @"dark"]) return UIBlurEffectStyleDark;
+    
+  #ifdef TARGET_OS_TV
+    if ([self.blurType isEqual: @"extraDark"]) return UIBlurEffectStyleExtraDark;
+    if ([self.blurType isEqual: @"regular"]) return UIBlurEffectStyleRegular;
+    if ([self.blurType isEqual: @"prominent"]) return UIBlurEffectStyleProminent;
+  #endif
+    
   return UIBlurEffectStyleDark;
 }
 

--- a/src/BlurView.ios.js
+++ b/src/BlurView.ios.js
@@ -17,7 +17,14 @@ class BlurView extends Component {
 
 BlurView.propTypes = {
   ...(ViewPropTypes || View.propTypes),
-  blurType: PropTypes.oneOf(['dark', 'light', 'xlight']),
+  blurType: PropTypes.oneOf([
+    'dark',
+    'light',
+    'xlight',
+    'prominent',
+    'regular',
+    'extraDark',
+  ]),
   blurAmount: PropTypes.number,
 };
 

--- a/src/BlurView.ios.js
+++ b/src/BlurView.ios.js
@@ -2,6 +2,12 @@ import React, { Component, PropTypes } from 'react';
 import { View, requireNativeComponent, ViewPropTypes } from 'react-native';
 
 class BlurView extends Component {
+  setNativeProps = nativeProps => {
+    if (this._root) {
+      this._root.setNativeProps(nativeProps);
+    }
+  }
+
   render() {
     return (
       <NativeBlurView

--- a/src/VibrancyView.ios.js
+++ b/src/VibrancyView.ios.js
@@ -2,6 +2,12 @@ import React, { Component, PropTypes } from 'react';
 import { requireNativeComponent } from 'react-native';
 
 class VibrancyView extends Component {
+  setNativeProps = nativeProps => {
+    if (this._root) {
+      this._root.setNativeProps(nativeProps);
+    }
+  }
+
   render() {
     return (
       <NativeVibrancyView


### PR DESCRIPTION
Add three new blur types available on tvOS

- extraDark
- prominent
- regular

You can see [UIBlurEffectStyle](https://developer.apple.com/documentation/uikit/uiblureffectstyle)

I have added [setNativeProps](https://facebook.github.io/react-native/docs/direct-manipulation.html) to use it in [TouchableHighlight](https://facebook.github.io/react-native/docs/touchablehighlight.html)

