### PR TITLE
fix OS TV target check

### DIFF
--- a/ios/BlurView.m
+++ b/ios/BlurView.m
@@ -54,7 +54,7 @@
   if ([self.blurType isEqual: @"light"]) return UIBlurEffectStyleLight;
   if ([self.blurType isEqual: @"dark"]) return UIBlurEffectStyleDark;
     
-  #ifdef TARGET_OS_TV
+  #if TARGET_OS_TV
     if ([self.blurType isEqual: @"extraDark"]) return UIBlurEffectStyleExtraDark;
     if ([self.blurType isEqual: @"regular"]) return UIBlurEffectStyleRegular;
     if ([self.blurType isEqual: @"prominent"]) return UIBlurEffectStyleProminent;


### PR DESCRIPTION
Previous condition wrongly returns true causing the following error:
```error: 'UIBlurEffectStyleExtraDark' is unavailable: not available on iOS```