### PR TITLE
Remove deprecated Android package override

### DIFF
--- a/android/src/main/java/com/cmcewen/blurview/BlurViewPackage.java
+++ b/android/src/main/java/com/cmcewen/blurview/BlurViewPackage.java
@@ -21,11 +21,6 @@ public class BlurViewPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Arrays.<ViewManager>asList(
                 new BlurViewManager()

--- a/android/src/main/java/com/cmcewen/blurview/BlurViewPackage.java
+++ b/android/src/main/java/com/cmcewen/blurview/BlurViewPackage.java
@@ -20,6 +20,13 @@ public class BlurViewPackage implements ReactPackage {
         return modules;
     }
 
+   // if react native < 47, open code
+   /* @Override
+    public List<Class<? extends JavaScriptModule>> createJSModules() {		
+      return Collections.emptyList();		
+    }		
+	*/	
+   
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Arrays.<ViewManager>asList(


### PR DESCRIPTION
This responds to a [breaking change](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8) in React Native 0.47+