### PR TITLE
Update Readme to reflect the Android compile issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ A component for UIVisualEffectView's blur and vibrancy effect on iOS, and [500px
 
 ```
 android {
+    // make sure to use 23.0.3 instead of 23.0.1
+    buildToolsVersion '23.0.3'
+
     // ...
     defaultConfig {
         // Add these lines below the existing config


### PR DESCRIPTION
According to [this](https://stackoverflow.com/a/36586107/828487), there is a bug related to ` which has been fixed in `gradle-plugin 2.1.0` and `Build-Tools 23.0.3`. This PR simple update the doc to reflect that