### PR TITLE
Fixes a NullPointerException that crashes the app

### DIFF
--- a/android/src/main/java/com/cmcewen/blurview/BlurViewManager.java
+++ b/android/src/main/java/com/cmcewen/blurview/BlurViewManager.java
@@ -50,7 +50,7 @@ public class BlurViewManager extends SimpleViewManager<BlurringView> {
 
     @ReactProp(name = "viewRef")
     public void setViewRef(BlurringView view, int viewRef) {
-        if (context != null && context.getCurrentActivity() != null) {}
+        if (context != null && context.getCurrentActivity() != null) {
           View viewToBlur = context.getCurrentActivity().findViewById(viewRef);
 
           if (viewToBlur != null) {

--- a/android/src/main/java/com/cmcewen/blurview/BlurViewManager.java
+++ b/android/src/main/java/com/cmcewen/blurview/BlurViewManager.java
@@ -50,10 +50,12 @@ public class BlurViewManager extends SimpleViewManager<BlurringView> {
 
     @ReactProp(name = "viewRef")
     public void setViewRef(BlurringView view, int viewRef) {
-        View viewToBlur = context.getCurrentActivity().findViewById(viewRef);
+        if (context != null && context.getCurrentActivity() != null) {}
+          View viewToBlur = context.getCurrentActivity().findViewById(viewRef);
 
-        if (viewToBlur != null) {
-            view.setBlurredView(viewToBlur);
+          if (viewToBlur != null) {
+              view.setBlurredView(viewToBlur);
+          }
         }
     }
 }


### PR DESCRIPTION
* On certain devices (mostly Samsung tablets), we were getting a NullPointerException that caused our app to crash. This PR should fix it.
* I believe it was caused when `context.getCurrentActivity()` was `null`