### PR TITLE
Modify 'Header Search Path' for native iOS app to integrate react-nat…

### DIFF
--- a/ios/RNBlur.xcodeproj/project.pbxproj
+++ b/ios/RNBlur.xcodeproj/project.pbxproj
@@ -316,7 +316,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				HEADER_SEARCH_PATHS = "$(SRCROOT)/../../react-native/React/**";
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/../../react-native/React/**",
+					"$(BUILT_PRODUCTS_DIR)",
+				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -328,7 +331,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				HEADER_SEARCH_PATHS = "$(SRCROOT)/../../react-native/React/**";
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/../../react-native/React/**",
+					"$(BUILT_PRODUCTS_DIR)",
+				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = "-ObjC";


### PR DESCRIPTION
Modify 'Header Search Path' for native iOS app to integrate react-native-blur from react-native package.json.
```
In file included from /Users/OceanHorn/SourceTree/mmms/node_modules/react-native-blur/ios/VibrancyViewManager.m:1:
/Users/OceanHorn/SourceTree/mmms/node_modules/react-native-blur/ios/VibrancyViewManager.h:1:9: fatal error: 'React/RCTViewManager.h' file not found
#import <React/RCTViewManager.h>
        ^~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.

```