### PR TITLE
Enable regular and prominent BlurEffectStyles for iOS 10.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ android {
   - `light` - light blur type
   - `dark` - dark blur type
   - `extraDark` - extra dark blur type (tvOS only)
-  - `regular` - regular blur type (tvOS only)
-  - `prominent` - prominent blur type (tvOS only)
+  - `regular` - regular blur type (iOS 10+ and tvOS only)
+  - `prominent` - prominent blur type (iOS 10+ and tvOS only)
 - `blurAmount` (Default: 10, Number)
   - `0-100` - Adjusts blur intensity
 

--- a/examples/Basic/index.ios.js
+++ b/examples/Basic/index.ios.js
@@ -67,7 +67,7 @@ class Basic extends Component {
           </Text>
 
           <SegmentedControlIOS
-            values={['xlight', 'light', 'dark']}
+            values={['xlight', 'light', 'dark', 'regular', 'prominent']}
             selectedIndex={this.state.blurActiveSegment}
             onChange={(event) => {this._onBlurChange(event)}}
             onValueChange={(value) => {this._onBlurValueChange(value)}}
@@ -89,7 +89,7 @@ class Basic extends Component {
           </Text>
 
           <SegmentedControlIOS
-            values={['xlight', 'light', 'dark']}
+            values={['xlight', 'light', 'dark', 'regular', 'prominent']}
             selectedIndex={this.state.vibrancyActiveSegment}
             onChange={(event) => {this._onVibrancyChange(event)}}
             onValueChange={(value) => {this._onVibrancyValueChange(value)}}

--- a/ios/BlurView.m
+++ b/ios/BlurView.m
@@ -53,13 +53,18 @@
   if ([self.blurType isEqual: @"xlight"]) return UIBlurEffectStyleExtraLight;
   if ([self.blurType isEqual: @"light"]) return UIBlurEffectStyleLight;
   if ([self.blurType isEqual: @"dark"]) return UIBlurEffectStyleDark;
-    
-  #if TARGET_OS_TV
-    if ([self.blurType isEqual: @"extraDark"]) return UIBlurEffectStyleExtraDark;
+
+  #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 100000 /* __IPHONE_10_0 */
     if ([self.blurType isEqual: @"regular"]) return UIBlurEffectStyleRegular;
     if ([self.blurType isEqual: @"prominent"]) return UIBlurEffectStyleProminent;
   #endif
-    
+
+  #if TARGET_OS_TV
+    if ([self.blurType isEqual: @"regular"]) return UIBlurEffectStyleRegular;
+    if ([self.blurType isEqual: @"prominent"]) return UIBlurEffectStyleProminent;
+    if ([self.blurType isEqual: @"extraDark"]) return UIBlurEffectStyleExtraDark;
+  #endif
+
   return UIBlurEffectStyleDark;
 }
 


### PR DESCRIPTION
Previously `regular`, `prominent` and `extraDark` were only available on tvOS. iOS 10.0+ adds support for `regular` and `prominent` according to the [BlurEffect.Style docs](https://developer.apple.com/documentation/uikit/uiblureffect/style).

https://developer.apple.com/documentation/uikit/uiblureffect/style/regular
https://developer.apple.com/documentation/uikit/uiblureffect/style/prominent

`extraDark` Remains tvOS only.