### PR TITLE
Remove react dependency from Podspec

### DIFF
--- a/react-native-blur.podspec
+++ b/react-native-blur.podspec
@@ -10,5 +10,4 @@ Pod::Spec.new do |s|
   s.homepage      = "https://github.com/react-native-community/react-native-blur"
   s.source        = { :git => "https://github.com/react-native-community/react-native-blur.git" }
 
-  s.dependency 'React'
 end


### PR DESCRIPTION
With this dependency present, people cannot install this using Cocoapods if they created their app using `react-native init`. It attempts to install React 0.11.0. Adding a pod line for React in the podfile is not a good idea for people who started their projects with `react-native init` because you'll get double references to the same files. See the following issues:

https://github.com/invertase/react-native-firebase/issues/324