### PR TITLE
type definition updates

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,17 +1,21 @@
 import * as React from 'react';
-import { ViewStyle } from 'react-native';
+import { StyleProp, ViewStyle } from 'react-native';
 
 export interface BlurViewProperties {
-  blurType: 'xlight' | 'light' | 'dark'
+  blurType:
+    | 'xlight'
+    | 'light'
+    | 'dark'
     // tvOS only
-    | 'extraDark' | 'regular' | 'prominent';
+    | 'extraDark'
+    | 'regular'
+    | 'prominent';
   blurAmount?: number; // 0 - 100
-  style?: ViewStyle;
+  style?: StyleProp<ViewStyle>;
   viewRef?: number | null;
 }
 
 export class BlurView extends React.Component<BlurViewProperties, {}> {}
-
 
 export interface VibrancyViewProperties extends BlurViewProperties {}
 


### PR DESCRIPTION
When in strict mode, TypeScript complains when trying to assign a style from a StyleSheet. Adding `StyleProp` solves this problem.