### PR TITLE
Update build.gradle to prevent compilation errors

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,12 +11,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    compileSdkVersion rootProject.properties.get('compileSdkVersion', 25)
+    buildToolsVersion rootProject.properties.get('buildToolsVersion', '25.0.3')
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion rootProject.properties.get('targetSdkVersion', 22)
         versionCode 1
         versionName "1.0"
 
@@ -33,5 +33,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:[0.32,)'
+    implementation 'com.facebook.react:react-native:[0.32,)'
 }


### PR DESCRIPTION
This uses the new `implementation` syntax instead of `compile` which errors now and also honors the rootProjects sdk specifications. 

Prevent the following gradle errors: 

```
Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html

The specified Android SDK Build Tools version (25.0.3) is ignored, as it is below the minimum supported version (28.0.3) for Android Gradle Plugin 3.2.1.
Android SDK Build Tools 28.0.3 will be used.
To suppress this warning, remove "buildToolsVersion '25.0.3'" from your build.gradle file, as each version of the Android Gradle Plugin now has a default version of the build tools.
```