### PR TITLE
add `pod install` to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ npm install react-native-blur
 react-native link react-native-blur
 ```
 
+3. (iOS only) Install
+
+```
+cd ios
+pod install
+```
+
 3. (Android only) Add the following to `android/app/build.gradle`
 
 ```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ cd ios
 pod install
 ```
 
-3. (Android only) Add the following to `android/app/build.gradle`
+4. (Android only) Add the following to `android/app/build.gradle`
 
 ```
 android {
@@ -51,7 +51,7 @@ android {
 }
 ```
 
-4. (Android only, optional) 
+5. (Android only, optional) 
 If you've defined _[project-wide properties](https://developer.android.com/studio/build/gradle-tips.html)_ (**recommended**) in your root `build.gradle`, this library will detect the presence of the following properties:
 
 ```groovy
@@ -68,13 +68,13 @@ ext {
 }
 ```
 
-5. Include the library in your code:
+6. Include the library in your code:
 
 ```javascript
 import { BlurView, VibrancyView } from "react-native-blur";
 ```
 
-6. Compile and have fun!
+7. Compile and have fun!
 
 ### BlurView
 


### PR DESCRIPTION
I hit this error https://github.com/react-native-community/react-native-blur/issues/290 and realized I needed to run `pod install` first. This PR adds the step to the readme.