### PR TITLE
Fallback background color for A11y reduce transparency

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ import { BlurView, VibrancyView } from "@react-native-community/blur";
     - `ultraThinMaterialLight` - An adaptable blur effect that creates the appearance of an ultra-thin material.
 - `blurAmount` (Default: 10, Number)
   - `0-100` - Adjusts blur intensity
+- `reducedTransparencyFallbackColor` (Color) (iOS only)
+  - `black, white, #rrggbb, etc` - background color to use if accessibility setting ReduceTransparency is enabled
 
 > Note: The maximum `blurAmount` on Android is 32, so higher values will be clamped to 32.
 
@@ -122,6 +124,7 @@ export default class Menu extends Component {
           viewRef={this.state.viewRef}
           blurType="light"
           blurAmount={10}
+          reducedTransparencyFallbackColor="white"
         />
         <Text>I'm the non blurred text because I got rendered on top of the BlurView</Text>
       </View>
@@ -146,9 +149,11 @@ const styles = StyleSheet.create({
 
 In this example, the `Image` component will be blurred, because the `BlurView` in positioned on top. But the `Text` will stay unblurred.
 
+If the [accessibility setting `Reduce Transparency`](https://support.apple.com/guide/iphone/display-settings-iph3e2e1fb0/ios) is enabled the `BlurView` will use `reducedTransparencyFallbackColor` as it's background color rather than blurring. If no `reducedTransparencyFallbackColor` is provided, the`BlurView`will use the default fallback color (white, black, or grey depending on `blurType`)
+
 ### VibrancyView
 
-**Uses the same properties as `BlurView` (`blurType` and `blurAmount`).**
+**Uses the same properties as `BlurView` (`blurType`, `blurAmount`, and `reducedTransparencyFallbackColor`).**
 
 > The vibrancy effect lets the content underneath a blurred view show through more vibrantly
 

--- a/example/App.js
+++ b/example/App.js
@@ -60,6 +60,7 @@ export default class Basic extends Component {
           <BlurView
             blurType={this.state.blurBlurType}
             blurAmount={100}
+            reducedTransparencyFallbackColor={'pink'}
             style={[styles.blurView]}>
             <Text style={[styles.text, { color: tintColor }]}>
               Blur component ({platform})
@@ -84,6 +85,7 @@ export default class Basic extends Component {
           <VibrancyView
             blurType={this.state.vibrancyBlurType}
             blurAmount={10}
+            reducedTransparencyFallbackColor={'pink'}
             style={[styles.container, styles.blurContainer]}>
 
             <Text style={styles.text}>

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ import * as React from "react";
 import { StyleProp, ViewStyle } from "react-native";
 
 export interface BlurViewProperties {
-  blurType:
+  blurType?:
     | "xlight"
     | "light"
     | "dark"
@@ -28,6 +28,7 @@ export interface BlurViewProperties {
     // tvOS only
     | "extraDark"
   blurAmount?: number // 0 - 100
+  reducedTransparencyFallbackColor?: string
   style?: StyleProp<ViewStyle>
   blurRadius?: number
   downsampleFactor?: number

--- a/index.js.flow
+++ b/index.js.flow
@@ -33,8 +33,9 @@ export type BlurType =
   | 'extraDark';
 
 export type BlurViewProps = {
-  blurType: BlurType,
-  blurAmount: number, // 0 - 100
+  blurType?: BlurType,
+  blurAmount?: number, // 0 - 100,
+  reducedTransparencyFallbackColor?: String,
   style?: ?ViewStyleProp,
 };
 

--- a/ios/BlurView.h
+++ b/ios/BlurView.h
@@ -3,11 +3,15 @@
 
 @interface BlurView : UIView
 
-@property (nonatomic, copy) NSString *blurType;
-@property (nonatomic, copy) NSNumber *blurAmount;
+@property (nonatomic, copy, nullable) NSString *blurType;
+@property (nonatomic, copy, nullable) NSNumber *blurAmount;
+@property (nonatomic, copy, nullable) UIColor *reducedTransparencyFallbackColor;
 
-@property (nonatomic, strong) BlurEffectWithAmount *blurEffect;
-@property (nonatomic, strong) UIVisualEffectView *blurEffectView;
+@property (nonatomic, strong, nullable) BlurEffectWithAmount *blurEffect;
+@property (nonatomic, strong, nullable) UIVisualEffectView *blurEffectView;
+@property (nonatomic, strong, nullable) UIView *reducedTransparencyFallbackView;
 
 - (void)updateBlurEffect;
+- (void)updateFallbackView;
+- (BOOL)useReduceTransparencyFallback;
 @end

--- a/ios/BlurViewManager.m
+++ b/ios/BlurViewManager.m
@@ -12,5 +12,6 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_VIEW_PROPERTY(blurType, NSString);
 RCT_EXPORT_VIEW_PROPERTY(blurAmount, NSNumber);
+RCT_EXPORT_VIEW_PROPERTY(reducedTransparencyFallbackColor, UIColor);
 
 @end

--- a/ios/VibrancyView.m
+++ b/ios/VibrancyView.m
@@ -30,7 +30,11 @@
 }
 
 - (void)insertReactSubview:(id<RCTComponent>)subview atIndex:(NSInteger)atIndex {
+  if ([self useReduceTransparencyFallback]) {
+    [self addSubview:(UIView*)subview];
+  } else {
     [self.vibrancyEffectView.contentView addSubview:(UIView*)subview];
+  }
 }
 
 - (void)updateBlurEffect
@@ -43,6 +47,26 @@
 {
   self.vibrancyEffect = [UIVibrancyEffect effectForBlurEffect:self.blurEffect];
   self.vibrancyEffectView.effect = self.vibrancyEffect;
+}
+
+- (void)updateFallbackView
+{
+  [super updateFallbackView];
+
+  if ([self useReduceTransparencyFallback]) {
+    for (UIView *subview in self.blurEffectView.contentView.subviews) {
+      [subview removeFromSuperview];
+      [self addSubview:subview];
+    }
+  } else {
+    for (UIView *subview in self.subviews) {
+      if (subview == self.blurEffectView) continue;
+      if (subview == self.reducedTransparencyFallbackView) continue;
+
+      [subview removeFromSuperview];
+      [self.blurEffectView.contentView addSubview:subview];
+    }
+  }
 }
 
 @end

--- a/ios/VibrancyViewManager.m
+++ b/ios/VibrancyViewManager.m
@@ -12,5 +12,6 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_VIEW_PROPERTY(blurType, NSString);
 RCT_EXPORT_VIEW_PROPERTY(blurAmount, NSNumber);
+RCT_EXPORT_VIEW_PROPERTY(reducedTransparencyFallbackColor, UIColor);
 
 @end


### PR DESCRIPTION
# Summary

When [Reduce Transparency](https://support.apple.com/guide/iphone/display-settings-iph3e2e1fb0/ios) is enabled (iOS only) the BlurView falls back to a non-transparent view with a black, white, or grey background. This is not always ideal as the content above the BlurView may not meet accessibility contrast requirements.

On iOS I've added a new prop, `reducedTransparencyFallbackColor`, which will be used as the background color when Reduce Transparency is enabled. When the prop is not configured the BlurView and VibrancyView will fallback to background color defined by the system. 

## Test Steps

1. Enable Reduce Transparency (Settings -> General -> Accessibility -> Reduce Transparency)
2. Open the example app. The BlurView and VibrancyView will fallback to 'pink'
3. In `example/App.ios.js` modify the `reducedTransparencyFallbackColor` prop test different fallback colors. Remove the reducedTransparencyFallbackColor prop to use the default system colors. 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌ (Not applicable)     |

## Checklist

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
- [x] I added a sample use of the API in the example project (`example/App.js`)
