### PR TITLE
enable prettier by default

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,8 +1,6 @@
 {
-  "requirePragma": true,
   "singleQuote": true,
   "trailingComma": "all",
   "bracketSpacing": false,
-  "jsxBracketSameLine": true,
-  "parser": "flow"
+  "jsxBracketSameLine": true
 }

--- a/example/App.js
+++ b/example/App.js
@@ -2,7 +2,7 @@
  * Basic [iOS] Example for react-native-blur
  * https://github.com/react-native-community/react-native-blur
  */
-import React, { Component } from 'react';
+import React, {Component} from 'react';
 import {
   Image,
   SegmentedControlIOS,
@@ -13,7 +13,7 @@ import {
   View,
 } from 'react-native';
 
-import { BlurView, VibrancyView } from '@react-native-community/blur';
+import {BlurView, VibrancyView} from '@react-native-community/blur';
 
 export default class Basic extends Component {
   constructor(props) {
@@ -37,7 +37,9 @@ export default class Basic extends Component {
   }
 
   _onVibrancyChange(event) {
-    this.setState({vibrancyActiveSegment: event.nativeEvent.selectedSegmentIndex});
+    this.setState({
+      vibrancyActiveSegment: event.nativeEvent.selectedSegmentIndex,
+    });
   }
 
   _onVibrancyValueChange(value) {
@@ -62,17 +64,22 @@ export default class Basic extends Component {
             blurAmount={100}
             reducedTransparencyFallbackColor={'pink'}
             style={[styles.blurView]}>
-            <Text style={[styles.text, { color: tintColor }]}>
+            <Text style={[styles.text, {color: tintColor}]}>
               Blur component ({platform})
             </Text>
-            {Platform.OS === 'ios' &&
-            <SegmentedControlIOS
-              values={['xlight', 'light', 'dark', 'regular', 'prominent']}
-              selectedIndex={this.state.blurActiveSegment}
-              onChange={(event) => {this._onBlurChange(event);}}
-              onValueChange={(value) => {this._onBlurValueChange(value);}}
-              tintColor={tintColor}
-            />}
+            {Platform.OS === 'ios' && (
+              <SegmentedControlIOS
+                values={['xlight', 'light', 'dark', 'regular', 'prominent']}
+                selectedIndex={this.state.blurActiveSegment}
+                onChange={(event) => {
+                  this._onBlurChange(event);
+                }}
+                onValueChange={(value) => {
+                  this._onBlurValueChange(value);
+                }}
+                tintColor={tintColor}
+              />
+            )}
           </BlurView>
         </View>
 
@@ -81,25 +88,27 @@ export default class Basic extends Component {
             VibrancyView is only supported on iOS, and must contain child views,
             otherwise the vibrancy effect doesn't work.
           */
-          Platform.OS === 'ios' &&
-          <VibrancyView
-            blurType={this.state.vibrancyBlurType}
-            blurAmount={10}
-            reducedTransparencyFallbackColor={'pink'}
-            style={[styles.container, styles.blurContainer]}>
+          Platform.OS === 'ios' && (
+            <VibrancyView
+              blurType={this.state.vibrancyBlurType}
+              blurAmount={10}
+              reducedTransparencyFallbackColor={'pink'}
+              style={[styles.container, styles.blurContainer]}>
+              <Text style={styles.text}>Vibrancy component (iOS-only)</Text>
 
-            <Text style={styles.text}>
-              Vibrancy component (iOS-only)
-            </Text>
-
-            <SegmentedControlIOS
-              values={['xlight', 'light', 'dark', 'regular', 'prominent']}
-              selectedIndex={this.state.vibrancyActiveSegment}
-              onChange={(event) => {this._onVibrancyChange(event);}}
-              onValueChange={(value) => {this._onVibrancyValueChange(value);}}
-              tintColor="white"
-            />
-          </VibrancyView>
+              <SegmentedControlIOS
+                values={['xlight', 'light', 'dark', 'regular', 'prominent']}
+                selectedIndex={this.state.vibrancyActiveSegment}
+                onChange={(event) => {
+                  this._onVibrancyChange(event);
+                }}
+                onValueChange={(value) => {
+                  this._onVibrancyValueChange(value);
+                }}
+                tintColor="white"
+              />
+            </VibrancyView>
+          )
         }
       </View>
     );
@@ -107,22 +116,21 @@ export default class Basic extends Component {
 
   render() {
     return (
-      <View
-        style={styles.container}>
+      <View style={styles.container}>
         <Image
           source={require('./bgimage.jpeg')}
           resizeMode="cover"
-          style={styles.img}/>
+          style={styles.img}
+        />
 
-        { this.state.showBlurs ? this.renderBlurs() : null }
+        {this.state.showBlurs ? this.renderBlurs() : null}
 
-        <View
-          style={styles.blurToggle}>
+        <View style={styles.blurToggle}>
           <Switch
             onValueChange={(value) => this.setState({showBlurs: value})}
-            value={this.state.showBlurs} />
+            value={this.state.showBlurs}
+          />
         </View>
-
       </View>
     );
   }

--- a/example/index.js
+++ b/example/index.js
@@ -1,7 +1,3 @@
-/**
- * @format
- */
-
 import {AppRegistry} from 'react-native';
 import App from './App';
 import {name as appName} from './app.json';

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "lint": "eslint src index.js"
+    "lint": "eslint src index.js example"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
   },
   "lint-staged": {
     "*.{js,json,css,md}": [
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   }
 }

--- a/src/BlurView.android.js
+++ b/src/BlurView.android.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {
   View,
@@ -16,7 +16,7 @@ const OVERLAY_COLORS = {
 
 class BlurView extends Component {
   componentDidMount() {
-    DeviceEventEmitter.addListener('ReactNativeBlurError', message => {
+    DeviceEventEmitter.addListener('ReactNativeBlurError', (message) => {
       throw new Error(`[ReactNativeBlur]: ${message}`);
     });
   }
@@ -33,12 +33,12 @@ class BlurView extends Component {
   }
 
   blurRadius() {
-    const { blurRadius, blurAmount } = this.props;
+    const {blurRadius, blurAmount} = this.props;
 
     if (blurRadius != null) {
       if (blurRadius > 25) {
         throw new Error(
-          `[ReactNativeBlur]: blurRadius cannot be greater than 25! (was: ${blurRadius})`
+          `[ReactNativeBlur]: blurRadius cannot be greater than 25! (was: ${blurRadius})`,
         );
       }
       return blurRadius;
@@ -55,7 +55,7 @@ class BlurView extends Component {
   }
 
   downsampleFactor() {
-    const { downsampleFactor, blurRadius } = this.props;
+    const {downsampleFactor, blurRadius} = this.props;
     if (downsampleFactor != null) {
       return downsampleFactor;
     }
@@ -63,7 +63,7 @@ class BlurView extends Component {
   }
 
   render() {
-    const { style } = this.props;
+    const {style} = this.props;
 
     return (
       <NativeBlurView
@@ -71,8 +71,7 @@ class BlurView extends Component {
         downsampleFactor={this.downsampleFactor()}
         overlayColor={this.overlayColor()}
         pointerEvents="none"
-        style={StyleSheet.compose(styles.transparent, style)}
-      >
+        style={StyleSheet.compose(styles.transparent, style)}>
         {this.props.children}
       </NativeBlurView>
     );
@@ -80,7 +79,7 @@ class BlurView extends Component {
 }
 
 const styles = StyleSheet.create({
-  transparent: { backgroundColor: 'transparent' },
+  transparent: {backgroundColor: 'transparent'},
 });
 
 BlurView.propTypes = {

--- a/src/BlurView.ios.js
+++ b/src/BlurView.ios.js
@@ -1,9 +1,14 @@
-import React, { Component } from 'react';
+import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import {View, requireNativeComponent, ViewPropTypes, StyleSheet} from 'react-native';
+import {
+  View,
+  requireNativeComponent,
+  ViewPropTypes,
+  StyleSheet,
+} from 'react-native';
 
 class BlurView extends Component {
-  setNativeProps = nativeProps => {
+  setNativeProps = (nativeProps) => {
     if (this._root) {
       this._root.setNativeProps(nativeProps);
     }
@@ -12,7 +17,7 @@ class BlurView extends Component {
   render() {
     return (
       <NativeBlurView
-        ref={e => (this._root = e)}
+        ref={(e) => (this._root = e)}
         {...this.props}
         style={StyleSheet.compose(styles.transparent, this.props.style)}
       />
@@ -21,7 +26,7 @@ class BlurView extends Component {
 }
 
 const styles = StyleSheet.create({
-  transparent: { backgroundColor: 'transparent' },
+  transparent: {backgroundColor: 'transparent'},
 });
 
 BlurView.propTypes = {

--- a/src/VibrancyView.ios.js
+++ b/src/VibrancyView.ios.js
@@ -1,9 +1,9 @@
-import React, { Component } from 'react';
+import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {requireNativeComponent, StyleSheet} from 'react-native';
 
 class VibrancyView extends Component {
-  setNativeProps = nativeProps => {
+  setNativeProps = (nativeProps) => {
     if (this._root) {
       this._root.setNativeProps(nativeProps);
     }
@@ -20,7 +20,7 @@ class VibrancyView extends Component {
 }
 
 const styles = StyleSheet.create({
-  transparent: { backgroundColor: 'transparent' },
+  transparent: {backgroundColor: 'transparent'},
 });
 
 VibrancyView.propTypes = {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

I removed `"requirePragma": true` from `prettierrc` because that option means prettier is not enabled unless explicitly turned on using the `@format` pragma (as it was in `example/index.js`).

After that I just ran `eslint --fix` and the code now follows the specified config.


<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

- eslint passes (it does locally :) )

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
