### PR TITLE
Remove RenderScript Support Library remains

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,23 +41,7 @@ cd ios
 pod install
 ```
 
-4. (Android only) Add the following to `android/app/build.gradle`
-
-```
-android {
-    // make sure to use 23.0.3 or greater
-    buildToolsVersion '23.0.3'
-
-    // ...
-    defaultConfig {
-        // Add these lines below the existing config
-        renderscriptTargetApi 23
-        renderscriptSupportModeEnabled true
-    }
-}
-```
-
-5. (Android only, optional) 
+4. (Android only, optional)
 If you've defined _[project-wide properties](https://developer.android.com/studio/build/gradle-tips.html)_ (**recommended**) in your root `build.gradle`, this library will detect the presence of the following properties:
 
 ```groovy
@@ -74,13 +58,13 @@ ext {
 }
 ```
 
-6. Include the library in your code:
+5. Include the library in your code:
 
 ```javascript
 import { BlurView, VibrancyView } from "@react-native-community/blur";
 ```
 
-7. Compile and have fun!
+6. Compile and have fun!
 
 ### BlurView
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,9 +24,6 @@ android {
         targetSdkVersion safeExtGet('targetSdkVersion', 22)
         versionCode 1
         versionName "1.0"
-
-        renderscriptTargetApi 23
-        renderscriptSupportModeEnabled true
     }
     lintOptions {
         abortOnError false

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -107,8 +107,6 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
-        renderscriptTargetApi 23
-        renderscriptSupportModeEnabled true
     }
     splits {
         abi {


### PR DESCRIPTION
## Summary

Removes remains of the RenderScript Support Library because we use the native (`android.renderscript`) APIs since https://github.com/react-native-community/react-native-blur/commit/7dc337ab1ba5cc973cb762e5b81939e72907f1e2. See also [Accessing RenderScript APIs from Java](https://developer.android.com/guide/topics/renderscript/compute#access-rs-apis).

## Test Plan

I’ve tested this change by running the example app on a device and on the Android Emulator.