### PR TITLE
Recommend pod-install for setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ react-native link @react-native-community/blur
 3. (iOS only) Install to Xcode:
 
 ```
-cd ios
-pod install
+npx pod-install
 ```
 
 4. (Android only, optional)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

We've been recommending devs use `npx pod-install` since it will attempt to install cocoapods CLI if it's not available on the computer (cite [React Navigation setup guide](https://reactnavigation.org/docs/getting-started/#installing-dependencies-into-a-bare-react-native-project)). This has proved very useful for Expo users who are now migrating to the bare workflow and want to use community packages in their projects.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
