### PR TITLE
Use version from package.json in podspec

### DIFF
--- a/react-native-blur.podspec
+++ b/react-native-blur.podspec
@@ -1,6 +1,10 @@
+require "json"
+
+package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+
 Pod::Spec.new do |s|
   s.name          = "react-native-blur"
-  s.version       = "0.8.0"
+  s.version       = package["version"]
   s.source_files  = "ios/*.{h,m}"
   s.ios.deployment_target = '8.0'
   s.tvos.deployment_target = '9.0'


### PR DESCRIPTION
The current version in `react-native-blur.podspec` (v0.8.0) does not match the version in `package.json` (v3.6.0). By fetching the version from `package.json` inside the podspec, we don’t need to manually maintain the version number in two places.

[create-react-native-module](https://github.com/brodybits/create-react-native-module), [which is used in React Native’s docs](https://reactnative.dev/docs/native-modules-setup), uses the same technique.