### PR TITLE
Remove outdated viewRef from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ export default class Menu extends Component {
 {/* in terms of positioning and zIndex-ing everything before the BlurView will be blurred */}
         <BlurView
           style={styles.absolute}
-          viewRef={this.state.viewRef}
           blurType="light"
           blurAmount={10}
           reducedTransparencyFallbackColor="white"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

I was a bit confused while upgrading to the latest version, while seeing `viewRef` being used in the example, but not in other places.

It has been removed as a part of this PR: https://github.com/react-native-community/react-native-blur/pull/358, so line I removed is just a leftover.
