### PR TITLE
Cleanup and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ or npm:
 npm install --save @react-native-community/blur
 ```
 
-2. Link your native dependencies:
+2. **React-Native 0.59 and below only**: Link your native dependencies:
 
 ```
 react-native link @react-native-community/blur
@@ -38,6 +38,10 @@ react-native link @react-native-community/blur
 
 ```
 npx pod-install
+```
+Or, if you already have installed [Cocoapods](https://cocoapods.org/) on your system:
+```
+cd ios && pod install
 ```
 
 4. (Android only, optional)
@@ -120,7 +124,6 @@ export default class Menu extends Component {
 {/* in terms of positioning and zIndex-ing everything before the BlurView will be blurred */}
         <BlurView
           style={styles.absolute}
-          viewRef={this.state.viewRef}
           blurType="light"
           blurAmount={10}
           reducedTransparencyFallbackColor="white"


### PR DESCRIPTION
# Summary

This PR addresses a few issues in the README file to avoid confusion for new users
* Clarify projects should not link the module with autolinking
* Suggest the "standard" way of installing pods with `pod install`
* Remove the obsolete `viewRef` prop from the example

## Test Plan
N/A: This is pure documentation fixes

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
